### PR TITLE
Add docs, error handling for my rushed work from 2 years ago

### DIFF
--- a/src/main/java/io/zucchini/circuitsimtester/api/BaseMemory.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/BaseMemory.java
@@ -3,9 +3,15 @@ package io.zucchini.circuitsimtester.api;
 import java.io.InputStream;
 import java.util.Scanner;
 
+/**
+ * Base class inherited by {@link Ram} and {@link Rom}. Handles loading {@code
+ * .dat}s exported from CircuitSim from an {@link InputStream}.
+ */
 public abstract class BaseMemory {
     public abstract void store(int address, int value);
 
+    // TODO: Provide some mechanism in CircuitSimExtension to open a file
+    //       and preload it into RAM/ROM
     /**
      * Loads a stream of a dat file into this component's memory. Format
      * is the same as the .dat files saved in the CircuitSim memory

--- a/src/main/java/io/zucchini/circuitsimtester/api/Button.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/Button.java
@@ -1,11 +1,19 @@
 package io.zucchini.circuitsimtester.api;
 
-// TODO FIXME document
+/**
+ * Allows pretending to push a button placed in a subcircuit.
+ * <p>
+ * (In reality, this manipulates an InputPin wired to where the button was;
+ * see {@link MockPulser})
+ */
 public class Button extends MockPulser {
     public Button(InputPin mockPin, Subcircuit subcircuit) {
         super(mockPin, subcircuit);
     }
 
+    /**
+     * This pushes the button. Crazy, right?
+     */
     public void press() {
         pulse();
     }

--- a/src/main/java/io/zucchini/circuitsimtester/api/Clock.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/Clock.java
@@ -2,16 +2,35 @@ package io.zucchini.circuitsimtester.api;
 
 import java.util.function.BooleanSupplier;
 
-// TODO FIXME document
+/**
+ * Allows pretending to tick a Clock component placed in a subcircuit.
+ * <p>
+ * (In reality, this manipulates an InputPin wired to where the clock component was;
+ * see {@link MockPulser})
+ */
 public class Clock extends MockPulser {
     public Clock(InputPin mockPin, Subcircuit subcircuit) {
         super(mockPin, subcircuit);
     }
 
+    /**
+     * Tick the clock once.
+     */
     public void tick() {
         pulse();
     }
 
+    /**
+     * Tick the clock until {@code stopWhen} returns true.
+     *
+     * @param maxCycleCount the number of cycles before timeout (to avoid
+     *                      infinitely spinning)
+     * @param stopWhen returns true when we can stop ticking the clock (e.g.,
+     *                 the student's processor has finished running and is
+     *                 sending the "done" signal)
+     * @return the number of ticks performed until stopWhen returned true. May
+     *         be zero if the condition was initially met
+     */
     public long tickUntil(long maxCycleCount, BooleanSupplier stopWhen) {
         long ticks = 0;
         while (!stopWhen.getAsBoolean()) {

--- a/src/main/java/io/zucchini/circuitsimtester/api/MockPulser.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/MockPulser.java
@@ -1,6 +1,24 @@
 package io.zucchini.circuitsimtester.api;
 
-// TODO FIXME document
+/**
+ * Similar to {@link MockRegister} but much simpler: manipulates an InputPin
+ * which replaced a clock or button and is used to send "pulses" into the
+ * circuit. By "pulse", I mean an input like this:
+ * <pre>
+ * 1            _
+ *             | |
+ *             | |
+ *             | |
+ * 0 __________| |___________
+ *
+ *         Time ---&gt;
+ * </pre>
+ * Notice that could be a button press or the rising edge of the clock signal
+ * (in CircuitSim we do not have to worry about propagation delay, thank God),
+ * hence this is a base class used for {@link Button} and {@link Clock}. Those
+ * classes have their own more specialized methods for sending pulses that
+ * ultimately call {@link #pulse()}.
+ */
 public abstract class MockPulser {
     protected InputPin mockPin;
     protected Subcircuit subcircuit;
@@ -18,6 +36,10 @@ public abstract class MockPulser {
         return subcircuit;
     }
 
+    /**
+     * Set the mock pin to 0, then 1, then 0 again to simulate the "pulse"
+     * drawn above in the lede.
+     */
     protected void pulse() {
         mockPin.set(0b0);
         mockPin.set(0b1);

--- a/src/main/java/io/zucchini/circuitsimtester/api/Register.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/Register.java
@@ -60,7 +60,25 @@ public class Register {
         return reg;
     }
 
-    // TODO FIXME document
+    /**
+     * Mocks this register with a {@link MockRegister}. See {@link
+     * MockRegister} and {@link
+     * Subcircuit#mockRegister(com.ra4king.circuitsim.simulator.components.memory.Register)}
+     * for details.
+     * <p>
+     * You probably <b>should not be calling this directly</b> — use the
+     * following code instead and let {@link
+     * io.zucchini.circuitsimtester.extension.CircuitSimExtension} handle this
+     * for you:
+     * <pre>
+     * {@literal @}SubcircuitComponent(bits=16)
+     * private MockRegister myFunRegister;
+     * </pre>
+     *
+     * @return a mocked version of this register
+     * @see MockRegister
+     * @see Subcircuit#mockRegister(com.ra4king.circuitsim.simulator.components.memory.Register)
+     */
     public MockRegister mock() {
         return subcircuit.mockRegister(reg);
     }

--- a/src/main/java/io/zucchini/circuitsimtester/api/Rom.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/Rom.java
@@ -3,7 +3,7 @@ package io.zucchini.circuitsimtester.api;
 import com.ra4king.circuitsim.simulator.components.memory.ROM;
 
 /**
- * Wraps a CircuitSim RAM component.
+ * Wraps a CircuitSim ROM component.
  *
  * @author Austin Adams
  */
@@ -12,10 +12,10 @@ public class Rom extends BaseMemory {
     private Subcircuit subcircuit;
 
     /**
-     * Creates a new Ram which wraps the provided {@code RAM}
+     * Creates a new Rom which wraps the provided {@code ROM}
      * component and which lives in the provided {@code Subcircuit}.
      *
-     * @param rom {@code RAM} component to wrap
+     * @param rom {@code ROM} component to wrap
      * @param subcircuit where this pin lives
      */
     public Rom(ROM rom, Subcircuit subcircuit) {
@@ -30,13 +30,13 @@ public class Rom extends BaseMemory {
     }
 
     /**
-     * Returns the internal CircuitSim {@code RAM} component this
+     * Returns the internal CircuitSim {@code ROM} component this
      * object wraps.
      * <p>
      * <b>This exposes an internal CircuitSim API. Do not use unless you
      *    know what you are doing.</b>
      *
-     * @return the CircuitSim {@code RAM} component wrapped by this
+     * @return the CircuitSim {@code ROM} component wrapped by this
      *         object.
      */
     public ROM getROM() {

--- a/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitComponent.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitComponent.java
@@ -7,28 +7,32 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 
 /**
- * Instructs {@link CircuitSimExtension}
- * to find and inject the Pin component into an {@link InputPin} or
- * {@link OutputPin} field in a test class.
+ * Instructs {@link CircuitSimExtension} to find and inject a CircuitSim
+ * component into the annotated field in a test class.
  * <p>
- * When you annotate an {@link InputPin} or {@link OutputPin} field in a
- * test class with this, {@link CircuitSimExtension}
- * will search the subcircuit for a Pin component with direction
- * (input/output) matching the type of the field, bitsize {@code
- * bits()}, and label {@code label()}. If {@code label()} is {@code ""}
- * (the default), it will search for a label matching the name of the
- * field instead.
+ * The annotated field can be a {@link InputPin}, {@link OutputPin}, {@link
+ * Register}, {@link MockRegister}, {@link Ram}, {@link Rom}, {@link Clock}, or
+ * {@link Button}.
+ * <p>
+ * When you annotate such a field in a test class with this annotation, {@link
+ * CircuitSimExtension} will search the subcircuit for a suitable component
+ * matching the requirements specified by the parameters to this annotation.
+ * <p>
+ * If {@link #label()} is {@code ""} (the default), it will search for a label
+ * matching the name of the field instead. Also, note that {@link #bits()} is
+ * required for some components.
  *
  * @see Subcircuit#lookupPin(String,boolean,int,boolean)
- * @see InputPin
- * @see OutputPin
+ * @see Subcircuit#lookupRegister(String,int,boolean)
+ * @see Subcircuit#lookupMemory(String,int,boolean,MemoryType)
+ * @see Subcircuit#mockRegister(com.ra4king.circuitsim.simulator.components.memory.Register)
+ * @see Subcircuit#mockPulser(String,boolean,PulserType)
  */
 @Retention(RUNTIME)
 public @interface SubcircuitComponent {
     /**
      * The label of a matching Pin. If empty (the default), {@link
-     * CircuitSimExtension} will
-     * use the name of the field.
+     * CircuitSimExtension} will use the name of the field.
      *
      * @return The label of a matching Pin.
      */
@@ -36,31 +40,75 @@ public @interface SubcircuitComponent {
 
     /**
      * The bit size of a matching Pin.
+     * <p>
+     * This parameter <b>must be provided</b> for {@link InputPin}s, {@link
+     * OutputPin}s, {@link Register}s, {@link MockRegister}s, {@link Ram}s, and
+     * {@link Rom}s.
+     * <p>
+     * This parameter <b>must NOT be provided</b> for {@link Clock}s and {@link
+     * Button}s.
      *
-     * @return The bit size of a matching Pin.
+     * @return The bit size of the desired compoment.
      */
-    // TODO FIXME document when this is requried
     int bits() default -1;
 
+    /**
+     * Used to tell the tester library not to look up the component by label
+     * and instead to find this component by looking for the only instance of
+     * such component present in the circuit (optionally recursively via {@link
+     * #recursiveSearch()}).
+     *
+     * @return true if this should be the only component of its type present in
+     *         the circuit (e.g., the only register), else false
+     */
     boolean onlyInstance() default false;
 
-    // TODO FIXME document
+    /**
+     * Search for this component not only directly in the subcircuit identified
+     * with {@link SubcircuitTest} but also in any subcircuits placed in it.
+     * <p>
+     * For example, if you are autograding a simple finite state machine
+     * homework and a student is a subcircuit enthusiast and places their
+     * actual register deep in many levels of subcircuits, this parameter
+     * would tell the autograder to go subcircuit spelunking to find the
+     * register.
+     *
+     * @return true to look for the desired component in subcircuits placed in
+     *         this subcircuit, else false
+     */
     boolean recursiveSearch() default false;
 
     /**
-     * The type of "pin". The default is a literal existing Pin
-     * component, but you can set this to {@code TUNNEL} to spy on the
-     * value of a tunnel by attaching an OutputPin to it. (The label is
-     * then the label of the tunnel you want to spy instead of the label
-     * of an existing pin.)
+     * For {@link OutputPin}s: The type of "pin". The default is a literal
+     * existing Pin component, but you can set this to {@code TUNNEL} to spy on
+     * the value of a tunnel by attaching an {@link OutputPin} to it. (The
+     * label is then the label of the tunnel you want to spy instead of the
+     * label of an existing pin.)
+     *
+     * This parameter is valid <b>only</b> for {@link OutputPin}s.
      *
      * @return An enum value determining if this should spy on a tunnel
      *         instead of controlling a Pin component
      */
     Type type() default Type.INFER;
 
+    /**
+     * Please see {@link SubcircuitComponent#type()} for details on this enum.
+     *
+     * @see SubcircuitComponent#type()
+     */
     enum Type {
+        /**
+         * Infer the type of component based on the annotated field type. This
+         * is the default behavior.
+         */
         INFER,
+        /**
+         * For {@link OutputPin}s: snitch on a tunnel instead of trying to find
+         * an output pin.
+         *
+         * @see SubcircuitComponent#type()
+         */
         TUNNEL,
     }
 }

--- a/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitTest.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitTest.java
@@ -29,7 +29,6 @@ public @interface SubcircuitTest {
      */
     String subcircuit();
 
-
     /**
      * Validate the subcircuit with these {@link Restrictor}s before
      * running any tests. Useful for checking for banned gates.


### PR DESCRIPTION
It looks like I did a pretty messy job in ausbin/circuitsim-grader-template#3, so add a lot of Javadoc that I should've added already. Making a PR into this repository instead of tormenting TAs by asking y'all to merge work between two now-diverged repositories

I don't know how Javadoc is generated in this repository. Should I go ahead and regenerate it? I'm on Java 14 and the diff was gargantuan (current Javadoc looks to be generated with Java 11) so I held off