### PR TITLE
Verify input pin count

### DIFF
--- a/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitTest.java
+++ b/src/main/java/io/zucchini/circuitsimtester/api/SubcircuitTest.java
@@ -75,4 +75,17 @@ public @interface SubcircuitTest {
      * @see Subcircuit#resetSimulation()
      */
     boolean resetSimulationBetween() default false;
+
+    /**
+     * Verify that the test contains a fixed number of input pins. This fixed
+     * number is determined by the number of InputPin variables with an
+     * {@link SubcircuitComponent} annotation.
+     * <p>
+     * Defaults to true as students frequently use input pins in place of
+     * constant pins, leading to undesired behavior.
+     *
+     * @return true if the number of input pins should be verified
+     *         false if it should not
+     */
+    boolean verifyInputPinCount() default true;
 }


### PR DESCRIPTION
Sometimes students add input pins instead of constant pins. This is bad (especially on timed labs) since when a new CircuitSim session loads their code, the input pin's value is read as a 0 since their values aren't persisted in CircuitSim save files.

Now,  to help avoid these kinds of errors. graders will (by default) verify that the number of input pins is correct.